### PR TITLE
Fix warning about use of uninitialized value $ip

### DIFF
--- a/lib/RT/Authen/OAuth2.pm
+++ b/lib/RT/Authen/OAuth2.pm
@@ -114,7 +114,7 @@ sub RequestAuthorization {
         redirect_uri => RT->Config->Get('OAuthRedirect'),
     );
 
-    my $ip = $ENV{REMOTE_ADDR};
+    my $ip = RT::Interface::Web::RequestENV('REMOTE_ADDR') || 'UNKNOWN';
     RT::Logger->info("OAuth 2 redirect from RequestAuthorization() from $ip");
     RT::Interface::Web::Redirect($auth->authorize);
 }
@@ -139,7 +139,7 @@ sub LogUserIn {
     # generic_error is displayed to the user to avoid leaking information
     # about the existance and status of user accounts in RT
     my $generic_error = RT->SystemUser->loc("Cannot login. Please contact your administrator.");
-    my $ip = $ENV{REMOTE_ADDR};
+    my $ip = RT::Interface::Web::RequestENV('REMOTE_ADDR') || 'UNKNOWN';
 
     RT::Logger->info("OAuth2 user already logged in, aborting; new request from $ip") if $session->{CurrentUser} and $session->{CurrentUser}->Id;
     return (0, $generic_error) if $session->{CurrentUser} and $session->{CurrentUser}->Id;


### PR DESCRIPTION
The warning and info msgs logged without this patch are:
```
[976] [Sun Aug 11 15:17:24 2024] [warning]: Use of uninitialized value $ip in concatenation (.) or string at /usr/share/perl5/vendor_perl/RT/Authen/OAuth2.pm line 116. (/usr/share/perl5/vendor_perl/RT/Authen/OAuth2.pm:116)
[976] [Sun Aug 11 15:17:24 2024] [info]: OAuth 2 redirect from RequestAuthorization() from  (/usr/share/perl5/vendor_perl/RT/Authen/OAuth2.pm:116)
```

The message logged in the patched PR is:
```
[7629] [Sun Aug 11 16:48:31 2024] [info]: OAuth 2 redirect from RequestAuthorization() from 192.168.0.1 (/usr/share/perl5/vendor_perl/RT/Authen/OAuth2.pm:116)
```