### PR TITLE
Fix broken image link if no LoginPageButton defined. Show name of configured provider.

### DIFF
--- a/README
+++ b/README
@@ -65,6 +65,9 @@ METHODS
         Returns the appropriate login button image for the active OAuth 2
         server. This is displayed on the RT login page.
 
+  IDPName()
+        Returns the name configured for the active OAuth 2 provider.
+
   LogOutURL()
         Returns the appropriate logout URL active OAuth 2 server.
 

--- a/html/Callbacks/OAuth/Elements/Login/Default
+++ b/html/Callbacks/OAuth/Elements/Login/Default
@@ -4,6 +4,15 @@ return unless RT->Config->Get('EnableOAuth2');
 <div id="authen-oauth-login">
 % my $next_state = $session{NextPage}->{$ARGS{next} || ''};
 % $next_state = $next_state->{url} if ref $next_state;
-<span class="input"><a
-href="<%RT->Config->Get('WebPath')%>/NoAuth/OAuth<% $next_state ?  "?next=$next_state" : "" %>"><img src="<% RT->Config->Get('WebPath') . RT::Authen::OAuth2::IDPLoginButtonImage() %>" alt="<% loc('Log in using OAuth 2') %>" /></a></span>
-</div>
+% my $LoginButtonImage = RT::Authen::OAuth2::IDPLoginButtonImage() || '';
+% my $IDPName = RT::Authen::OAuth2::IDPName();
+
+<span class="input">
+% if ($LoginButtonImage ne '') {
+<a href="<%RT->Config->Get('WebPath')%>/NoAuth/OAuth<% $next_state ?  "?next=$next_state" : "" %>">
+<img src="<% RT->Config->Get('WebPath') . $LoginButtonImage %>" alt="<% loc('Log in using OAuth 2') %> (<%$IDPName%>)" />
+% } else {
+<a class="btn button" href="<%RT->Config->Get('WebPath')%>/NoAuth/OAuth<% $next_state ?  "?next=$next_state" : "" %>">
+<% loc('Log in using OAuth 2') %> (<%$IDPName%>)
+% }
+</a></span></div>

--- a/lib/RT/Authen/OAuth2.pm
+++ b/lib/RT/Authen/OAuth2.pm
@@ -249,6 +249,25 @@ sub IDPLoginButtonImage {
     return RT->Config->Get('OAuthIDPs')->{$idp}->{LoginPageButton};
 }
 
+
+=head2 C<IDPName()>
+
+=over 4
+
+Returns the name configured for the active OAuth 2 provider.
+
+=back
+
+=cut
+
+
+sub IDPName {
+    my $self = shift;
+    my $idp = RT->Config->Get('OAuthIDP');
+    return RT->Config->Get('OAuthIDPs')->{$idp}->{name} || $idp;
+}
+
+
 =head2 C<LogOutURL()>
 
 =over 4


### PR DESCRIPTION

Fix broken image link if no LoginPageButton defined. Show name of configured provider.

- Display a button instead of invalid img link if `LoginPageButton` is not defined.
- Show the configured idp name in alt text or button description.
