### PR TITLE
Add option to add new users to specified groups. Help text for OAuthNewUserOptions.

### DIFF
--- a/etc/OAuth2_Config.pm
+++ b/etc/OAuth2_Config.pm
@@ -36,7 +36,8 @@ Set($OAuthCreateNewUser, 0);
 
 =item C<$OAuthNewUserOptions>
 
-Set this to enable auto-creating new users based on the OAuth2 data.
+Set additional options when auto-creating new users. Default creates users as Privileged.
+ - Set Privileged => 0 to create Unprivileged users.
 
     Set($OAuthNewUserOptions, {
             Privileged => 1,

--- a/etc/OAuth2_Config.pm
+++ b/etc/OAuth2_Config.pm
@@ -32,7 +32,6 @@ Set this to enable auto-creating new users based on the OAuth2 data.
 
 Set($OAuthCreateNewUser, 0);
 
-
 =over 4
 
 =item C<$OAuthNewUserOptions>
@@ -47,6 +46,23 @@ Set this to enable auto-creating new users based on the OAuth2 data.
 =back
 
 =cut
+
+=over 4
+
+=item C<%OAuthNewUserGroups>
+
+Set this to always automatically add new users to RT groups.
+
+    Set(%OAuthNewUserGroups,
+        'google' => [ 'Staff', 'Support' ],
+        'auth0'=> [ 'Users' ],
+        ...
+    );
+
+=back
+
+=cut
+
 
 =over 4
 

--- a/lib/RT/Authen/OAuth2.pm
+++ b/lib/RT/Authen/OAuth2.pm
@@ -202,8 +202,8 @@ sub LogUserIn {
         $group->LoadUserDefinedGroup( $add_group );
 
             unless ($group->Id) {
-                $RT::Logger->error("Couldn't add ".$user." to ".$add_group." - group does not exist");
-                return(0, $generic_error) unless $user->id;
+                $RT::Logger->error("Error adding account for ".$name." - Group ".$add_group." does not exist");
+                return(0, $generic_error);
             }
       }
 
@@ -285,6 +285,24 @@ Returns the appropriate logout URL active OAuth 2 server.
 =back
 
 =cut
+
+=head2 C<IDPName()>
+
+=over 4
+
+Returns the name configured for the active OAuth 2 provider.
+
+=back
+
+=cut
+
+
+sub IDPName {
+    my $self = shift;
+    my $idp = RT->Config->Get('OAuthIDP');
+    return RT->Config->Get('OAuthIDPs')->{$idp}->{name} || $idp;
+}
+
 
 sub LogoutURL {
     my $next = shift;

--- a/lib/RT/Authen/OAuth2.pm
+++ b/lib/RT/Authen/OAuth2.pm
@@ -286,24 +286,6 @@ Returns the appropriate logout URL active OAuth 2 server.
 
 =cut
 
-=head2 C<IDPName()>
-
-=over 4
-
-Returns the name configured for the active OAuth 2 provider.
-
-=back
-
-=cut
-
-
-sub IDPName {
-    my $self = shift;
-    my $idp = RT->Config->Get('OAuthIDP');
-    return RT->Config->Get('OAuthIDPs')->{$idp}->{name} || $idp;
-}
-
-
 sub LogoutURL {
     my $next = shift;
     my $idp = RT->Config->Get('OAuthIDP');


### PR DESCRIPTION

This PR adds the following new option:-

`%OAuthNewUserGroups` - When new users are auto-created, always add them to specified group(s). The group MUST already exist in RT or user creation will fail.

```perl
    Set(%OAuthNewUserGroups,
        'google' => [ 'Staff', 'Support' ],
        'auth0'=> [ 'Users' ],
        ...
    );
```

Option is configurable per IDP - this is to allow a future version of this extension to support multiple simultaneous OAuth2 providers, for example allow customers / staff or different departments  to authenticate via different providers and add them to different RT groups, based on where they logged in from.
